### PR TITLE
Update to add support for v0.3-tf-v0.9.3 provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ source/tf-v0.9.3-ibm-k8s-v0.1
 source/tf-v0.9.3-ibm-provider-v0.1
 source/tf-v0.9.3-ibm-provider-v0.2
 source/tf-v0.9.3-ibm-provider-v0.2.1
+source/v0.3-tf-v0.9.3
 
 .sass-cache/
 

--- a/config.sh
+++ b/config.sh
@@ -4,6 +4,7 @@ RELEASES=( \
   #"tf-v0.9.3-ibm-k8s-v0.1" \
   "tf-v0.9.3-ibm-provider-v0.2" \
   "tf-v0.9.3-ibm-provider-v0.2.1" \
+  "v0.3-tf-v0.9.3" \
 )
 
 # The version of the provider that schematics is using


### PR DESCRIPTION
Not the actual docs build, that lands on `gh-pages` -- `publish.sh` commit can be seen here: https://github.com/IBM-Bluemix/tf-ibm-docs/commit/302b05b79e49c241cc622896be0219e339da2e8f